### PR TITLE
Dependencies

### DIFF
--- a/linkedhashmap.cabal
+++ b/linkedhashmap.cabal
@@ -68,8 +68,6 @@ benchmark benchmarks
   hs-source-dirs:      benchmarks
                        src 
   build-depends:       base, containers, deepseq, hashable, unordered-containers
-                     , tasty >= 0.10.0.2
-                     , tasty-hunit >= 0.9.0.1
                      , criterion >= 1.0.2.0
   default-language:    Haskell2010
   ghc-options:      -O2

--- a/linkedhashmap.cabal
+++ b/linkedhashmap.cabal
@@ -43,10 +43,10 @@ library
                        Data.LinkedHashMap.IntMap
   -- other-modules:       
   other-extensions:    BangPatterns
-  build-depends:       base >=4.6 && <4.8
+  build-depends:       base >=4.6 && <5
                      , containers >=0.5 && <0.6
-                     , deepseq >= 1.1
-                     , hashable >=1.2 && <1.3
+                     , deepseq >=1.1 && <2
+                     , hashable >=1.2 && <2
                      , unordered-containers >=0.2 && <0.3
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -55,9 +55,9 @@ test-suite linkedhashmap-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   build-depends:       base, containers, deepseq, hashable, unordered-containers
-                     , mtl >= 2.1.3.1
-                     , tasty >= 0.10.0.2
-                     , tasty-hunit >= 0.9.0.1
+                     , mtl >=2.1 && <3
+                     , tasty >=0.10 && <0.11
+                     , tasty-hunit >=0.9 && <0.10
   hs-source-dirs:      tests
                        src
   default-language:    Haskell2010
@@ -68,7 +68,7 @@ benchmark benchmarks
   hs-source-dirs:      benchmarks
                        src 
   build-depends:       base, containers, deepseq, hashable, unordered-containers
-                     , criterion >= 1.0.2.0
+                     , criterion >=1 && <2
   default-language:    Haskell2010
   ghc-options:      -O2
                     -fmax-simplifier-iterations=10

--- a/linkedhashmap.cabal
+++ b/linkedhashmap.cabal
@@ -43,7 +43,7 @@ library
                        Data.LinkedHashMap.IntMap
   -- other-modules:       
   other-extensions:    BangPatterns
-  build-depends:       base >=4.7 && <4.8
+  build-depends:       base >=4.6 && <4.8
                      , containers >=0.5 && <0.6
                      , deepseq >= 1.1
                      , hashable >=1.2 && <1.3
@@ -54,7 +54,7 @@ library
 test-suite linkedhashmap-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  build-depends:       base >=4.7 && <4.8
+  build-depends:       base >=4.6 && <4.8
                      , containers >= 0.5.5.1
                      , deepseq >= 1.1
                      , hashable >= 1.2.2.0
@@ -71,7 +71,7 @@ benchmark benchmarks
   main-is:        Main.hs
   hs-source-dirs:      benchmarks
                        src 
-  build-depends:       base >=4.7 && <4.8
+  build-depends:       base >=4.6 && <4.8
                      , containers >= 0.5.5.1
                      , hashable >= 1.2.2.0
                      , tasty >= 0.10.0.2

--- a/linkedhashmap.cabal
+++ b/linkedhashmap.cabal
@@ -54,14 +54,10 @@ library
 test-suite linkedhashmap-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  build-depends:       base >=4.6 && <4.8
-                     , containers >= 0.5.5.1
-                     , deepseq >= 1.1
-                     , hashable >= 1.2.2.0
-                     , tasty >= 0.10.0.2
+  build-depends:       base, containers, deepseq, hashable, unordered-containers
                      , mtl >= 2.1.3.1
+                     , tasty >= 0.10.0.2
                      , tasty-hunit >= 0.9.0.1
-                     , unordered-containers >= 0.2.5.0
   hs-source-dirs:      tests
                        src
   default-language:    Haskell2010
@@ -71,14 +67,10 @@ benchmark benchmarks
   main-is:        Main.hs
   hs-source-dirs:      benchmarks
                        src 
-  build-depends:       base >=4.6 && <4.8
-                     , containers >= 0.5.5.1
-                     , hashable >= 1.2.2.0
+  build-depends:       base, containers, deepseq, hashable, unordered-containers
                      , tasty >= 0.10.0.2
                      , tasty-hunit >= 0.9.0.1
-                     , unordered-containers >= 0.2.5.0
                      , criterion >= 1.0.2.0
-                     , deepseq >=1.3 && <1.4
   default-language:    Haskell2010
   ghc-options:      -O2
                     -fmax-simplifier-iterations=10


### PR DESCRIPTION
The version you specified on your 'base' dependency was too stringent. I relaxed the constraints, and all the tests ran just fine.

I also did a little cleanup to prevent similar issues on a few other dependencies.
