### PR TITLE
Bump outdated constraints on `containers`, `tasty`, and `tasty-hunit`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .cabal-sandbox/
 cabal.sandbox.config
 dist/
+dist-newstyle/
+cabal.project.local

--- a/linkedhashmap.cabal
+++ b/linkedhashmap.cabal
@@ -44,7 +44,7 @@ library
   -- other-modules:       
   other-extensions:    BangPatterns
   build-depends:       base >=4.6 && <5
-                     , containers >=0.5 && <0.6
+                     , containers >=0.5 && <0.7
                      , deepseq >=1.1 && <2
                      , hashable >=1.2 && <2
                      , unordered-containers >=0.2 && <0.3
@@ -56,19 +56,19 @@ test-suite linkedhashmap-tests
   main-is: Main.hs
   build-depends:       base, containers, deepseq, hashable, unordered-containers
                      , mtl >=2.1 && <3
-                     , tasty >=0.10 && <0.11
-                     , tasty-hunit >=0.9 && <0.10
+                     , tasty >=0.10 && <1.5
+                     , tasty-hunit >=0.9 && <0.11
+                     , linkedhashmap
   hs-source-dirs:      tests
-                       src
   default-language:    Haskell2010
 
 benchmark benchmarks
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   hs-source-dirs:      benchmarks
-                       src 
   build-depends:       base, containers, deepseq, hashable, unordered-containers
                      , criterion >=1 && <2
+                     , linkedhashmap
   default-language:    Haskell2010
   ghc-options:      -O2
                     -fmax-simplifier-iterations=10


### PR DESCRIPTION
This PR bumps the outdated constraints on `containers`, `tasty`, and `tasty-hunit`.

I've tested the code, both locally and on CI (see [this run](https://github.com/wenkokke/linkedhashmap/actions/runs/3532510170)), and the tests still pass.
